### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ document.addEventListener('lazybeforeunveil', function(e){
 ```js
 $(document).on('lazybeforesizes', function(e){
     //use width of parent node instead of the image width itself
-    e.detail.width = $(e.target).closest(':not(picture)').innerWidth() || e.detail.width;
+    e.detail.width = $(e.target).parents(':not(picture)').innerWidth() || e.detail.width;
 });
 ```
 


### PR DESCRIPTION
Changing example of using with of parent node instead of the image itself: closest() will start with the img itself and therefore use it instead of the parent, using parents() is more suitable.